### PR TITLE
Disable rollbar in fresh installation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ ROOT_REPORT_MAIL=example@localhost
 
 # Rollbar Error Tracking
 
-ROLLBAR_TOKEN=
-ROLLBAR_LEVEL=debug
+ROLLBAR_TOKEN=none
+ROLLBAR_LEVEL=none
 
 # Secondary parameters
 


### PR DESCRIPTION
Disable Rollbar configuration by setting its options to null in .env file in fresh installation to avoid any errors through the installation steps 