### PR TITLE
Only register RollbarServiceProvider when token is set

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -35,7 +35,7 @@ class AppServiceProvider extends ServiceProvider
             $this->app->register('Potsky\LaravelLocalizationHelpers\LaravelLocalizationHelpersServiceProvider');
         }
 
-        if ($this->app->environment() != 'testing') {
+        if (env('ROLLBAR_TOKEN', false)) {
             $this->app->register(RollbarServiceProvider::class);
         }
     }


### PR DESCRIPTION
This enhances post-install experience by fixing an Exception thrown
when no access token for Rollbar is provided.