### PR TITLE
Fix json_decode() expects parameter 1 to be string, array given

### DIFF
--- a/resources/views/manager/businesses/_notification.blade.php
+++ b/resources/views/manager/businesses/_notification.blade.php
@@ -17,7 +17,7 @@
     </td>
     <td>
         @if ($notification['extra'])
-            {{trans('notifications.'.$notification['body']['name'], ['user' => $notification['from']['name']] + json_decode($notification['extra'], true)) }}
+            {{trans('notifications.'.$notification['body']['name'], ['user' => $notification['from']['name']] + $notification['extra']) }}
         @else
             {{trans('notifications.'.$notification['body']['name'], ['user' => $notification['from']['name']]) }}
         @endif


### PR DESCRIPTION
Fix exception.

Since Notifynder fixes Extra array is empty if you call toArray, no longer json_decode is required.

https://github.com/fenos/Notifynder/issues/126