### PR TITLE
Change listeners to send notification emails with user preferred timezone

### DIFF
--- a/app/Listeners/SendAppointmentCancellationNotification.php
+++ b/app/Listeners/SendAppointmentCancellationNotification.php
@@ -51,6 +51,7 @@ class SendAppointmentCancellationNotification
             'email' => $event->appointment->contact->email,
         ];
         $this->transmail->locale($event->appointment->business->locale)
+                        ->timezone($event->user->pref('timezone'))
                         ->template('appointments.user._canceled')
                         ->subject('user.appointment.canceled.subject', ['business' => $event->appointment->business->name])
                         ->send($header, $params);

--- a/app/Listeners/SendAppointmentConfirmationNotification.php
+++ b/app/Listeners/SendAppointmentConfirmationNotification.php
@@ -51,6 +51,7 @@ class SendAppointmentConfirmationNotification
             'email' => $event->appointment->contact->email,
         ];
         $this->transmail->locale($event->appointment->business->locale)
+                        ->timezone($event->user->pref('timezone'))
                         ->template('appointments.user._confirmed')
                         ->subject('user.appointment.confirmed.subject', ['business' => $event->appointment->business->name])
                         ->send($header, $params);

--- a/app/Listeners/SendBookingNotification.php
+++ b/app/Listeners/SendBookingNotification.php
@@ -51,6 +51,7 @@ class SendBookingNotification
             'email' => $event->user->email,
         ];
         $this->transmail->locale($event->appointment->business->locale)
+                        ->timezone($event->user->pref('timezone'))
                         ->template('appointments.user._new')
                         ->subject('user.appointment.reserved.subject')
                         ->send($header, $params);
@@ -65,6 +66,7 @@ class SendBookingNotification
             'email' => $event->appointment->business->owner()->email,
         ];
         $this->transmail->locale($event->appointment->business->locale)
+                        ->timezone($event->appointment->business->owner()->pref('timezone'))
                         ->template('appointments.manager._new')
                         ->subject('manager.appointment.reserved.subject')
                         ->send($header, $params);

--- a/app/TransMail.php
+++ b/app/TransMail.php
@@ -31,6 +31,16 @@ class TransMail
     /**
      * @var string
      */
+    protected $timezone = null;
+
+    /**
+     * @var string
+     */
+    protected $revertTimezone = null;
+
+    /**
+     * @var string
+     */
     protected $subjectKey = '';
 
     /**
@@ -99,6 +109,28 @@ class TransMail
         return $this;
     }
 
+    public function timezone($timezone)
+    {
+        $this->revertTimezone = session()->get('timezone');
+
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    public function switchTimezone($timezone)
+    {
+        if($timezone !== null && $timezone != '')
+        {
+            $this->revertTimezone = session()->get('timezone');
+
+            session()->set('timezone', $timezone);
+            logger()->info("Switching timezone to $timezone for session");
+        }
+
+        return $this;
+    }
+
     /**
      * Set the template view path key.
      *
@@ -141,13 +173,15 @@ class TransMail
     public function send(array $header, array $params)
     {
         $this->switchLocale($this->locale);
+        $this->switchTimezone($this->timezone);
 
         Mail::send($this->getViewKey(), $params, function ($mail) use ($header) {
             $mail->to($header['email'], $header['name'])
                  ->subject($this->getSubject());
         });
-
+        
         $this->switchLocale($this->revertLocale);
+        $this->switchTimezone($this->revertTimezone);
     }
 
     /////////////


### PR DESCRIPTION
Before, a user could receive notifications in an unfamiliar timezone, thus generating confusion. Now every user should receive Appointment time information with his preferred timezone.

ADVICE: It will default to session() timezone if none is set as user preference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/timegridio/timegrid/94)
<!-- Reviewable:end -->
