### PR TITLE
Change to the Features hover state on the welcome template

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -29,6 +29,15 @@
         -ms-filter:     grayscale(20%);
         -o-filter:      grayscale(20%);
     }
+	.image-container {
+		position: relative;
+		display: inline-block;
+		width: 100px;
+		height: 100px;
+		background-size: cover;
+		background-position: center center;
+		border-radius: 4px;
+	}
     img:hover {
         filter: none;
         -webkit-filter: grayscale(0%);
@@ -38,16 +47,10 @@
     }
     #inspire {font-family: 'Arvo', serif;}
     .panel{
-        -o-transition:color .2s ease-out, background 1s ease-in;
-        -ms-transition:color .2s ease-out, background 1s ease-in;
-        -moz-transition:color .2s ease-out, background 1s ease-in;
-        -webkit-transition:color .2s ease-out, background 1s ease-in;
-        transition:color .2s ease-out, background 1s ease-in;
+    	text-align: center;
+    	border: none;
+    	box-shadow: none;
     }
-    #optimize:hover{background-color: #FFD8CC;}
-    #contact:hover{background-color: #FFF0CC;}
-    #do:hover{background-color: #E4FFCC;}
-    #love:hover{background-color: #FFCCEE;}
     </style>
 
 </head>
@@ -79,8 +82,8 @@
     <div class="row">
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="optimize">
-                <img src="{{asset('img/jumbo/optimize.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/optimize.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.1.title')}}</h3>
                     <p>{{trans('welcome.feature.1.content')}}</p>
@@ -89,8 +92,8 @@
         </div>
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="contact">
-                <img src="{{asset('img/jumbo/contact.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/contact.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.2.title')}}</h3>
                     <p>{{trans('welcome.feature.2.content')}}</p>
@@ -99,8 +102,8 @@
         </div>
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="do">
-                <img src="{{asset('img/jumbo/do.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/do.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.3.title')}}</h3>
                     <p>{{trans('welcome.feature.3.content')}}</p>
@@ -109,8 +112,8 @@
         </div>
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="love">
-                <img src="{{asset('img/jumbo/love.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/love.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.4.title')}}</h3>
                     <p>{{trans('welcome.feature.4.content')}}</p>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -22,13 +22,6 @@
         color:#fff;
         background-color: #367FA9;
     }
-    img {
-        filter: none;
-        -webkit-filter: grayscale(20%);
-        -moz-filter:    grayscale(20%);
-        -ms-filter:     grayscale(20%);
-        -o-filter:      grayscale(20%);
-    }
 	.image-container {
 		position: relative;
 		display: inline-block;
@@ -38,13 +31,6 @@
 		background-position: center center;
 		border-radius: 4px;
 	}
-    img:hover {
-        filter: none;
-        -webkit-filter: grayscale(0%);
-        -moz-filter:    grayscale(0%);
-        -ms-filter:     grayscale(0%);
-        -o-filter:      grayscale(0%);
-    }
     #inspire {font-family: 'Arvo', serif;}
     .panel{
     	text-align: center;


### PR DESCRIPTION
Firstly, this is my first very contribution to any open source projects so if there is anything I have not done or should be aware of, please don’t hesitate to inform me.

**Issue**
I found the hover state for the features panel on the homepage a bit misleading. I made the assumption that these would redirect to a different page/area. I’m not sure if anybody experienced the same confusion.

**Solution**
This pull request basically contain a removal the hover state with a few other styling changes. I’ve also made some changes to the image within each panel which places the the image within an image container as a background image. A small border radius has been added to this image container to be consistent to the current UI.

I’ve attached an image to show these changes.

![timegrid](https://cloud.githubusercontent.com/assets/7933597/26782073/a33d66d8-49e9-11e7-8222-25112850ac83.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/timegridio/timegrid/172)
<!-- Reviewable:end -->
