### PR TITLE
Changes to the Pricing Table & Wizard Templates

### DIFF
--- a/resources/views/manager/pricing.blade.php
+++ b/resources/views/manager/pricing.blade.php
@@ -23,6 +23,29 @@
         -webkit-transition: 300ms;
         transition: 300ms;
     }
+
+	.flat .plan li.noZoom {
+		 -o-transition-property: none !important;
+		 -moz-transition-property: none !important;
+		 -ms-transition-property: none !important;
+		 -webkit-transition-property: none !important;
+		 transition-property: none !important;
+
+		 /*CSS transforms*/
+		 -o-transform: none !important;
+		 -moz-transform: none !important;
+		 -ms-transform: none !important;
+		 -webkit-transform: none !important;
+		 transform: none !important;
+
+		 /*CSS animations*/
+		 -webkit-animation: none !important;
+		 -moz-animation: none !important;
+		 -o-animation: none !important;
+		 -ms-animation: none !important;
+		 animation: none !important;
+	}
+    
     .flat .plan li.plan-price {
         font-family: 'Lato', sans-serif;
         font-size: 2em;
@@ -61,12 +84,21 @@
         -ms-transform: scale(1.05);
         transform: scale(1.05);
     }
-    .plan-action .btn{
+
+    .flat .plan.featured :hover {
+        -webkit-transform: scale(1.05);
+        -ms-transform: scale(1.05);
+        transform: scale(1.05);
+    }
+
+    .plan-action .btn {
         font-family: 'Lato', sans-serif;
         font-size: 1.5em;
         border: 0px;
+        -webkit-transition: 300ms;
+        transition: 300ms;
     }
-    .plan-action .btn:hover{
+    .plan-action .btn:hover {
         background-color: #5CB85C;
     }
     .flat .plan.featured li.plan-name {
@@ -95,7 +127,7 @@
                     <li class="plan-name">
                         {{trans('pricing.plan.free.name')}}
                     </li>
-                    <li class="plan-hint">
+                    <li class="plan-hint noZoom">
                         {{trans('pricing.plan.free.hint')}}
                     </li>
                     <li class="plan-price">
@@ -113,6 +145,9 @@
                     <li id="p1_specialists">
                         {!! trans('pricing.feature.one_specialist') !!}
                     </li>
+                    <li class="noZoom">
+						<strike>{{ trans('pricing.feature.customized_support') }}</strike>
+                    </li>
                     <li class="plan-action">
                         <a href="{{ route('manager.business.register', ['plan' => 'free']) }}" class="btn btn-danger btn-lg">{!! Icon::cloud_upload() !!}&nbsp;{{ trans('pricing.plan.free.submit') }}</a>
                     </li>
@@ -124,7 +159,7 @@
                     <li class="plan-name">
                         {{trans('pricing.plan.premium.name')}}
                     </li>
-                    <li class="plan-hint">
+                    <li class="plan-hint noZoom">
                         {{trans('pricing.plan.premium.hint')}}
                     </li>
                     <li class="plan-price">

--- a/resources/views/manager/pricing.blade.php
+++ b/resources/views/manager/pricing.blade.php
@@ -124,7 +124,7 @@
         <div class="col-lg-offset-3 col-md-offset-3 col-xs-offset-1">
             <div class="col-lg-4 col-md-4 col-xs-6">
                 <ul class="plan plan1 featured" id="plan1">
-                    <li class="plan-name">
+                    <li class="plan-name noZoom">
                         {{trans('pricing.plan.free.name')}}
                     </li>
                     <li class="plan-hint noZoom">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -29,6 +29,15 @@
         -ms-filter:     grayscale(20%);
         -o-filter:      grayscale(20%);
     }
+	.image-container {
+		position: relative;
+		display: inline-block;
+		width: 100px;
+		height: 100px;
+		background-size: cover;
+		background-position: center center;
+		border-radius: 4px;
+	}
     img:hover {
         filter: none;
         -webkit-filter: grayscale(0%);
@@ -38,16 +47,10 @@
     }
     #inspire {font-family: 'Arvo', serif;}
     .panel{
-        -o-transition:color .2s ease-out, background 1s ease-in;
-        -ms-transition:color .2s ease-out, background 1s ease-in;
-        -moz-transition:color .2s ease-out, background 1s ease-in;
-        -webkit-transition:color .2s ease-out, background 1s ease-in;
-        transition:color .2s ease-out, background 1s ease-in;
+    	text-align: center;
+    	border: none;
+    	box-shadow: none;
     }
-    #optimize:hover{background-color: #FFD8CC;}
-    #contact:hover{background-color: #FFF0CC;}
-    #do:hover{background-color: #E4FFCC;}
-    #love:hover{background-color: #FFCCEE;}
     </style>
 
 </head>
@@ -79,8 +82,8 @@
     <div class="row">
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="optimize">
-                <img src="{{asset('img/jumbo/optimize.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/optimize.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.1.title')}}</h3>
                     <p>{{trans('welcome.feature.1.content')}}</p>
@@ -89,8 +92,8 @@
         </div>
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="contact">
-                <img src="{{asset('img/jumbo/contact.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/contact.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.2.title')}}</h3>
                     <p>{{trans('welcome.feature.2.content')}}</p>
@@ -99,8 +102,8 @@
         </div>
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="do">
-                <img src="{{asset('img/jumbo/do.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/do.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.3.title')}}</h3>
                     <p>{{trans('welcome.feature.3.content')}}</p>
@@ -109,8 +112,8 @@
         </div>
 
         <div class="col-md-3 col-sm-6 hero-feature">
-            <div class="thumbnail panel" id="love">
-                <img src="{{asset('img/jumbo/love.png')}}" alt="">
+            <div class="thumbnail panel">
+            	<div class="image-container" style="background-image:url('{{asset('img/jumbo/love.png')}}')"></div>
                 <div class="caption">
                     <h3>{{trans('welcome.feature.4.title')}}</h3>
                     <p>{{trans('welcome.feature.4.content')}}</p>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -22,13 +22,6 @@
         color:#fff;
         background-color: #367FA9;
     }
-    img {
-        filter: none;
-        -webkit-filter: grayscale(20%);
-        -moz-filter:    grayscale(20%);
-        -ms-filter:     grayscale(20%);
-        -o-filter:      grayscale(20%);
-    }
 	.image-container {
 		position: relative;
 		display: inline-block;
@@ -38,13 +31,6 @@
 		background-position: center center;
 		border-radius: 4px;
 	}
-    img:hover {
-        filter: none;
-        -webkit-filter: grayscale(0%);
-        -moz-filter:    grayscale(0%);
-        -ms-filter:     grayscale(0%);
-        -o-filter:      grayscale(0%);
-    }
     #inspire {font-family: 'Arvo', serif;}
     .panel{
     	text-align: center;

--- a/resources/views/wizard.blade.php
+++ b/resources/views/wizard.blade.php
@@ -1,6 +1,19 @@
 @extends('layouts.bare')
 
 @section('content')
+<style>
+	.caption {
+		height: 80px;
+		text-align: center;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+	.btn {
+        -webkit-transition: 300ms;
+        transition: 300ms;
+	}
+</style>
 <div class="container">
     <div class="row">
         {!! Alert::info(trans('wizard.alert')) !!}


### PR DESCRIPTION
I've made a small change to the pricing table.

**Add a new list item within the first pricing table** 
This list item has the text ~~Customized Support~~ within it. This mirrors the second pricing table but shows the user that it is not available with that pricing tier.

![screen shot 2017-06-16 at 14 47 01](https://user-images.githubusercontent.com/7933597/27229456-9625303a-52a3-11e7-95fe-ad927cae7785.png)

**Addition of a `noZoom` class** 
This stops scale transitions for any element with this class. This has been applied to the `.plan-name`, `.plan-hint` and the new list item in the first table. This will avoid any li coming out out the table edges due to the zoom.

**Color transition on button** 
A simple color transition has been added to the button.

**Wizard template**
This is a small change which sets a height for the caption box for the thumbnail. CSS rules were added to the `caption` class which uses flexbox to center its content. This has been tested in all languages to make sure there is no issue.

![screen shot 2017-06-16 at 15 21 01](https://user-images.githubusercontent.com/7933597/27234110-cbca6ff6-52b3-11e7-8bdc-af3ecff7ceeb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/timegridio/timegrid/174)
<!-- Reviewable:end -->
