### PR TITLE
enforce SSL on production mode

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,19 @@ use Illuminate\Support\ServiceProvider;
 class AppServiceProvider extends ServiceProvider
 {
     /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+		// Enfocre SSL in Production
+        if(config('app.env') === 'production') {
+           \URL::forceSchema('https');
+        }
+    }
+
+    /**
      * Register any application services.
      *
      * @return void


### PR DESCRIPTION
If you serve this App behind a reverse-proxy the `asset()` function does not correctly resolve into https:// links.

This is my attempts to fix this issue.